### PR TITLE
use toplevel openregister.org domain again

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -6,9 +6,9 @@ class Config(object):
     PROJECT_ROOT = os.path.abspath(os.path.join(APP_ROOT, os.pardir))
     SECRET_KEY = os.environ.get('SECRET_KEY')
 
-    COUNTRY_REGISTER = os.environ.get('COUNTRY_REGISTER', 'http://country.prod.openregister.org')
-    ADDRESS_REGISTER = os.environ.get('ADDRESS_REGISTER', 'http://address.prod.openregister.org')
-    ADDRESS_SEARCH = os.environ.get('ADDRESS_SEARCH', 'http://address-search.prod.openregister.org/2013-01-01/search')
+    COUNTRY_REGISTER = os.environ.get('COUNTRY_REGISTER', 'http://country.openregister.org')
+    ADDRESS_REGISTER = os.environ.get('ADDRESS_REGISTER', 'http://address.openregister.org')
+    ADDRESS_SEARCH = os.environ.get('ADDRESS_SEARCH', 'http://address-search.openregister.org/2013-01-01/search')
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/environment.sh
+++ b/environment.sh
@@ -1,4 +1,4 @@
 export SETTINGS=config.DevelopmentConfig
-export COUNTRY_REGISTER=http://country.prod.openregister.org
-export ADDRESS_REGISTER=http://address.prod.openregister.org
-export ADDRESS_SEARCH=http://address-search.prod.openregister.org/2013-01-01/search
+export COUNTRY_REGISTER=http://country.openregister.org
+export ADDRESS_REGISTER=http://address.openregister.org
+export ADDRESS_SEARCH=http://address-search.openregister.org/2013-01-01/search

--- a/widgets/templates/index.html
+++ b/widgets/templates/index.html
@@ -6,15 +6,18 @@
         <script src="{{asset_path}}javascripts/country-picker.js"></script>
         <script src="{{asset_path}}javascripts/address-lookup.js"></script>
 
-        {% raw %}
 
         <script id="address-template" type="text/x-jsrender">
-            <li><a href="http://address.prod.openregister.org/address/{{:address}}">
+            <li><a href="{{ address_register + '/address/{{:address}}' }}">
+        {% raw %}
                     {{if property}}{{:property}},{{/if}}
                     {{if street}}{{:street}},{{/if}}
                     {{if town}}{{:town}},{{/if}}
                     {{if postcode}}{{:postcode}}{{/if}}</a></li>
+        {% endraw %}
         </script>
+
+        {% raw %}
 
         <script id="country-template" type="text/x-jsrender">
           <option value="{{:country}}" data-alternative-spellings="{{:country}}">{{:name}}</option>


### PR DESCRIPTION
Now that country, address, and address-search are on the
openregister.org domain, we can use them there again.
