### PR TITLE
Now using '/records' resource instead of '/entries' resource

### DIFF
--- a/widgets/frontend/views.py
+++ b/widgets/frontend/views.py
@@ -42,13 +42,10 @@ def suggest_address():
 @frontend.route('/countries.json')
 def countries():
     country_register = current_app.config['COUNTRY_REGISTER']
-    url = "%s/entries.json?page-size=300" % country_register
+    url = "%s/records.json?page-size=300" % country_register
     resp = requests.get(url, headers=headers)
     countries = []
-    current_countries_code = []
     for e in resp.json():
-        if e['entry']['country'] not in current_countries_code :
-            current_countries_code.append(e['entry']['country'])
-            countries.append(e['entry'])
-    sorted_countries = sorted(countries, key=lambda country: country['name'])
-    return jsonify({'entries': sorted_countries})
+        countries.append(e['entry'])
+    countries = sorted(countries, key=lambda country: country['name'])
+    return jsonify({'entries': countries})


### PR DESCRIPTION
Till now countries demo was using `/entries` resource to collect all the countries because the `/records` resource used to return only 100 records. Now `/records` supports pagination so all the countries records can be retrieved.

changes confirms that the records resource is used instead of entries.
